### PR TITLE
Update pricing.md

### DIFF
--- a/Single-Pages/pricing.md
+++ b/Single-Pages/pricing.md
@@ -18,7 +18,7 @@ Collaboration           |  Y                 |  Y                          |  Y
 Forum Support           |  Y                 |  Y                          |  Y
 Email Support           |  Y(48hours)        |  Y(24hours)                 |  Y(12 hours)
 Phone Support           |  N                 |  N                          |  Y
-PCB order discount      |  N                 |  90%                        |  80%
+PCB order discount      |  N                 |  10%                        |  20%
 Advertisement(?)        |  Y                 |  N                          |  N
 Cloud Auto router (Coming soon)  |  Unknown    |  Unknown                     |  Unknown
 Cloud spice simulation  |  Y                 |  Y                          |  Y


### PR DESCRIPTION
I have just realised that on the Pricing page it says:

PCB order discount     N    90% 80%

Are you sure that is what you mean?

Because if the price of a PCB is $100 then a discount of 90% means that the cost goes down to $1!

I think what it should say is:

PCB order discount     N    10% 20%
